### PR TITLE
issue#2 fixing pitfall in regular expressions

### DIFF
--- a/app/models/mongoid_shortener/shortened_url.rb
+++ b/app/models/mongoid_shortener/shortened_url.rb
@@ -12,7 +12,7 @@ module MongoidShortener
 
     URL_PROTOCOL_HTTP = "http://"
 
-    REGEX_HTTP_URL = /^\s*(http[s]?:\/\/)?[a-z0-9]+([-.]{1}[a-z0-9]+)*\.[a-z]{2,5}(([0-9]{1,5})?\/.*)?\s*$/i
+    REGEX_HTTP_URL = /\A\s*(http[s]?:\/\/)?[a-z0-9]+([-.]{1}[a-z0-9]+)*\.[a-z]{2,5}(([0-9]{1,5})?\/.*)?\s*\z/i
     REGEX_LINK_HAS_PROTOCOL = Regexp.new('\Ahttp:\/\/|\Ahttps:\/\/', Regexp::IGNORECASE)
 
     validates_format_of :url, :with => REGEX_HTTP_URL

--- a/app/models/mongoid_shortener/shortened_url.rb
+++ b/app/models/mongoid_shortener/shortened_url.rb
@@ -23,8 +23,6 @@ module MongoidShortener
     validates_presence_of :unique_key
     validates_uniqueness_of :unique_key
 
-    attr_accessible :url
-
     before_validation :clean_destination_url, :init_unique_key, :on => :create
 
     # ensure the url starts with it protocol


### PR DESCRIPTION
I have fixed issue "ArgumentError: The provided regular expression is using multiline anchors (^ or $), which may present a security risk. Did you mean to use \A and \z, or forgot to add the :multiline => true option? #2"

https://github.com/siong1987/mongoid_shortener/issues/2 

please have a look and merge this into master.